### PR TITLE
Supernova: Don't print spurious late messages for immediate bundles

### DIFF
--- a/server/supernova/sc/sc_osc_handler.cpp
+++ b/server/supernova/sc/sc_osc_handler.cpp
@@ -875,8 +875,10 @@ void sc_osc_handler::handle_bundle(received_bundle const & bundle, endpoint_ptr 
     typedef osc::ReceivedBundleElement bundle_element;
 
     if (bundle_time <= now) {
-		time_tag late = now - bundle_time;
-		log_printf("late: %zu.%09zu\n", late.get_secs(), late.get_nanoseconds());
+        if (!bundle_time.is_immediate()) {
+            time_tag late = now - bundle_time;
+            log_printf("late: %zu.%09zu\n", late.get_secs(), late.get_nanoseconds());
+	};
         for (bundle_iterator it = bundle.ElementsBegin(); it != bundle.ElementsEnd(); ++it) {
             bundle_element const & element = *it;
 

--- a/server/supernova/utilities/time_tag.hpp
+++ b/server/supernova/utilities/time_tag.hpp
@@ -188,6 +188,11 @@ public:
         return seconds;
     }
     
+    bool is_immediate()
+    {
+      return data_ == 1;
+    }
+
     static time_tag from_ptime(boost::posix_time::ptime const & pt)
     {
         using namespace boost::gregorian;


### PR DESCRIPTION
I found this issue while testing your timedll branch -- supernova prints unnecessary "late" messages for bundles with "immediate" timestamps. The condition for printing a late message is if the time tag is less than now. An immediate time tag has a uint64 value == 1, which is always less than now.

The code is quite different between supercollider/supercollider/master and sonoro1234/supercollider/timedll, so I think I shouldn't make a pull request against the main repository. So I'm sending the PR specifically to your branch, and it can be pushed up to the main repository in due time.

Thanks for working on the timedll, by the way!

Tests:

```
s.sendMsg(\c_set, 0, 0.63);  // should not say "late"

s.sendBundle(0.2, [\c_set, 0, 0.63]);  // should not say "late"

s.sendBundle(0.0, [\c_set, 0, 0.63]);  // SHOULD (and does) say "late"

s.sendBundle(nil, [\c_set, 0, 0.63]);  // should not say "late," but does w/o fix
```